### PR TITLE
feat: make bookings pages public

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -22,14 +22,14 @@ export const PUBLIC_BUTTON_LINKS: NavigationLink[] = [
     label: 'Newsletter',
     href: '/nusc-letter',
   },
-]
-
-export const LOGGED_IN_BUTTON_LINKS: NavigationLink[] = [
-  ...PUBLIC_BUTTON_LINKS,
   {
     label: 'Bookings',
     href: '/bookings',
   },
+]
+
+export const LOGGED_IN_BUTTON_LINKS: NavigationLink[] = [
+  ...PUBLIC_BUTTON_LINKS,
   {
     label: 'Admin',
     href: '/admin',


### PR DESCRIPTION
Revert from Open House - we hid the bookings pages as it is quite ugly on mobile.