### PR TITLE
fix: handle errors in user control form

### DIFF
--- a/components/admin/users/UserControlForm.tsx
+++ b/components/admin/users/UserControlForm.tsx
@@ -39,29 +39,35 @@ function UserControlForm({ users, mutateUsers, mutateOrgs }: UserControlFormProp
       fetchUrl = process.env.NEXT_PUBLIC_BACKEND_URL + `user/${values.id}`
       method = 'PUT'
     }
-    const { responseJson, responseStatus } = await makeFetchToUrlWithAuth(
-      fetchUrl,
-      auth.token,
-      method,
-      JSON.stringify(values),
-    )
 
-    if (responseStatus === 200) {
-      toast(
-        makeSuccessToast(
-          values.id === -1 ? `User created successfully!` : `User edited successfully`,
-        ),
+    try {
+      const { responseJson, responseStatus } = await makeFetchToUrlWithAuth(
+        fetchUrl,
+        auth.token,
+        method,
+        JSON.stringify(values),
       )
-      mutateOrgs()
-      mutateUsers()
-      onClose()
-    } else {
-      toast(
-        makeErrorToast(
-          'Oh snap! There was an error when making the user',
-          JSON.stringify(responseJson.message),
-        ),
-      )
+
+      if (responseStatus === 200) {
+        toast(
+          makeSuccessToast(
+            values.id === -1 ? `User created successfully!` : `User edited successfully`,
+          ),
+        )
+        mutateOrgs()
+        mutateUsers()
+        onClose()
+      } else {
+        toast(
+          makeErrorToast(
+            'Oh snap! There was an error when making the user',
+            JSON.stringify(responseJson.message),
+          ),
+        )
+      }
+    } catch (err) {
+      console.error(err)
+      toast(makeErrorToast('Oh snap! There was an error when making the user', (err as Error).message))
     }
 
     setSubmitting(false)


### PR DESCRIPTION
When an error is triggered after submitting the form, the error
is not caught.

As such, no error toast is shown.

Let's fix this by adding a try..catch blog for the error when sending a
request.
If there is an error, then we show the error toast with the appropriate
message.
